### PR TITLE
Porkchop example final draft including notebook

### DIFF
--- a/mission_design/earth_mars_transfer_window.ipynb
+++ b/mission_design/earth_mars_transfer_window.ipynb
@@ -1,0 +1,248 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "15127448",
+   "metadata": {},
+   "source": [
+    "# Earth-Mars transfer window design using Porkchop Plots\n",
+    "Copyright (c) 2010-2023, Delft University of Technology\n",
+    "All rigths reserved\n",
+    "This file is part of the Tudat. Redistribution and use in source and \n",
+    "binary forms, with or without modification, are permitted exclusively\n",
+    "under the terms of the Modified BSD license. You should have received\n",
+    "a copy of the license with this file. If not, please or visit:\n",
+    "http://tudat.tudelft.nl/LICENSE.\n",
+    "\n",
+    "## **Important**\n",
+    "This example requires the `tudatpy.trajectory_design.porkchop` module.\n",
+    "Please ensure that your version of tudatpy does include this module.\n",
+    "\n",
+    "## Summary\n",
+    "This example shows how the tudatpy `porkchop` module can be used to choose\n",
+    "an optimal launch and arrival date for an Earth-Mars transfer. By default,\n",
+    "the porkchop module uses a Lambert arc to compute the $\\Delta V$ required to\n",
+    "depart from the departure body (Earth in this case) and be captured by the \n",
+    "target body (in this case Mars).\n",
+    "\n",
+    "Users can provide a custom function to calculate the $\\Delta V$ required for any\n",
+    "given transfer. This can be done by supplying a `callable` (a function)\n",
+    "to the `porkchop` function via the argument\n",
+    "\n",
+    "    function_to_calculate_delta_v\n",
+    "\n",
+    "This opens the possibility to calculate the $\\Delta V$ required for any transfer\n",
+    "accounting for course correction manoeuvres along a planned trajectory.\n",
+    "\n",
+    "### Structure\n",
+    "This example consists of 3 sections:\n",
+    "\n",
+    "1. The imports, where we import the required modules\n",
+    "2. Data management, where we define the file where the porkchop data will be saved\n",
+    "3. The porkchop itself, which will only be recalculated if the user requests it"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57ec02e2",
+   "metadata": {},
+   "source": [
+    "## Import statements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3dd6f852",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# General imports\n",
+    "import os\n",
+    "import pickle\n",
+    "\n",
+    "# Use custom compiled Tudat version\n",
+    "import sys\n",
+    "sys.path.insert(0, '/mnt/e/studio/professional/work/2023-2024 Tudat/repos/tudat-bundle/cmake-build-release-wsl/tudatpy/')\n",
+    "\n",
+    "# Tudat imports\n",
+    "from tudatpy import constants\n",
+    "from tudatpy.interface import spice_interface\n",
+    "from tudatpy.astro.time_conversion import DateTime\n",
+    "from tudatpy.numerical_simulation import environment_setup\n",
+    "from tudatpy.trajectory_design.porkchop import porkchop, plot_porkchop"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b392321",
+   "metadata": {},
+   "source": [
+    "## Environment setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b91a8da",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load spice kernels\n",
+    "spice_interface.load_standard_kernels( )\n",
+    "\n",
+    "# Define global frame orientation\n",
+    "global_frame_orientation = 'ECLIPJ2000'\n",
+    "\n",
+    "# Create bodies\n",
+    "bodies_to_create = ['Sun', 'Venus', 'Earth', 'Moon', 'Mars', 'Jupiter', 'Saturn']\n",
+    "global_frame_origin = 'Sun'\n",
+    "body_settings = environment_setup.get_default_body_settings(\n",
+    "    bodies_to_create, global_frame_origin, global_frame_orientation)\n",
+    "\n",
+    "# Create environment model\n",
+    "bodies = environment_setup.create_system_of_bodies(body_settings)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8d7b32b",
+   "metadata": {},
+   "source": [
+    "## Porkchop Plots\n",
+    "We proceed to define the departure and target bodies and the time window for the transfer,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e44d7ea9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "departure_body = 'Earth'\n",
+    "target_body = 'Mars'\n",
+    "\n",
+    "earliest_departure_time = DateTime(2005,  4,  30)\n",
+    "latest_departure_time   = DateTime(2005, 10,   7)\n",
+    "\n",
+    "earliest_arrival_time   = DateTime(2005, 11,  16)\n",
+    "latest_arrival_time     = DateTime(2006, 12,  21)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "58f64818",
+   "metadata": {},
+   "source": [
+    "To ensure the porkchop plot is rendered with good resolution, we calculate the time resolution of the plot to be 0.5% of the smallest time window (either the arrival or the departure window):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3b57a24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set time resolution IN DAYS as 0.5% of the smallest window (be it departure, or arrival)\n",
+    "# This will result in fairly good time resolution, at a runtime of approximately 10 seconds\n",
+    "# Tune the time resolution to obtain results to your liking!\n",
+    "time_window_percentage = 0.5\n",
+    "time_resolution = time_resolution = min(\n",
+    "        latest_departure_time.epoch() - earliest_departure_time.epoch(),\n",
+    "        latest_arrival_time.epoch()   - earliest_arrival_time.epoch()\n",
+    ") / constants.JULIAN_DAY * time_window_percentage / 100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, we call the `porkchop` function, which will calculate the $\\Delta V$ required at each departure-arrival coordinate and display the plot, giving us\n",
+    "\n",
+    "- The optimal departure-arrival date combination\n",
+    "- The constant time-of-flight isochrones\n",
+    "- And more"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[departure_epochs, arrival_epochs, ΔV] = porkchop(\n",
+    "    bodies,\n",
+    "    global_frame_orientation,\n",
+    "    departure_body,\n",
+    "    target_body,\n",
+    "    earliest_departure_time,\n",
+    "    latest_departure_time,\n",
+    "    earliest_arrival_time,\n",
+    "    latest_arrival_time,\n",
+    "    time_resolution\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Variations\n",
+    "The Tudat `porkchop` module allows us to\n",
+    "\n",
+    "- Save the $\\Delta V$ map returned by `porkchop` and plot it again without recalculating with the `plot_porkchop` function\n",
+    "- Plot $\\Delta V$ (default) or C3 (specific energy), as well as choose whether to plot departure and arrival $\\Delta V$ together as the total $\\Delta V$ required for the transfer (default), or separately (in those cases in which the manoeuvre is performed in two burns, one at departure and one at arrival to the target planet).\n",
+    "\n",
+    "Let's make use of `plot_porkchop` to see all four combinations!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cases = [\n",
+    "    {'C3': False, 'total': False, 'threshold': 15 , 'filename': 'figures/ΔV.png'},\n",
+    "    {'C3': False, 'total': True,  'threshold': 15 , 'filename': 'figures/Δ_tot.png'},\n",
+    "    {'C3': True,  'total': False, 'threshold': 42 , 'filename': 'figures/C3.png'},\n",
+    "    {'C3': True,  'total': True,  'threshold': 100, 'filename': 'figures/C3_tot.png'}\n",
+    "]\n",
+    "\n",
+    "for case in cases:\n",
+    "    plot_porkchop(\n",
+    "        departure_body   = departure_body,\n",
+    "        target_body      = target_body,\n",
+    "        departure_epochs = departure_epochs, \n",
+    "        arrival_epochs   = arrival_epochs, \n",
+    "        delta_v          = ΔV,\n",
+    "        save             = True,\n",
+    "        **case\n",
+    "    )"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mission_design/earth_mars_transfer_window.py
+++ b/mission_design/earth_mars_transfer_window.py
@@ -1,3 +1,4 @@
+# Earth Mars transfer window design with Porkchop Plots
 ''' 
 Copyright (c) 2010-2023, Delft University of Technology
 All rigths reserved
@@ -83,9 +84,9 @@ target_body = 'Mars'
 if not os.path.isfile(data_file) or RECALCULATE_delta_v:
 
     # Tudat imports
-    from tudatpy.kernel.interface import spice_interface
-    from tudatpy.kernel.astro.time_conversion import DateTime
-    from tudatpy.kernel.numerical_simulation import environment_setup
+    from tudatpy.interface import spice_interface
+    from tudatpy.astro.time_conversion import DateTime
+    from tudatpy.numerical_simulation import environment_setup
 
     #--------------------------------------------------------------------
     #%% PORKCHOP PARAMETERS


### PR DESCRIPTION
Final draft of the porkchop module example including a Jupyter notebook.

The Python file **is not** directly obtained from the notebook, as I've included some helpful data management which is not really needed in the notebook, as the variables "live on" in the kernel and we can replot as many times as we want after generating the porkchop plot's delta V map.

In the case of the Python script, I pickle the map so users can re-run it to try new variations of the plot and options available to them through `plot_porkchop` without having to recalculate the map.